### PR TITLE
fix TypeError in train.py and train_student.py

### DIFF
--- a/train.py
+++ b/train.py
@@ -90,9 +90,9 @@ def clone_as_averaged_model(model, ema):
     averaged_model.to(device)
     averaged_model.load_state_dict(model.state_dict())
 
-    for name, _ in averaged_model.named_parameters():
+	for name, param in averaged_model.named_parameters():
         if name in ema.shadow:
-            averaged_model.named_parameters()[name] = ema.shadow[name].clone()
+            param.data = ema.shadow[name].clone().data
     return averaged_model
 
 

--- a/train_student.py
+++ b/train_student.py
@@ -108,9 +108,10 @@ def clone_as_averaged_model(model_s, ema):
     if args.num_gpu > 1:
         averaged_model = torch.nn.DataParallel(averaged_model)
     averaged_model.load_state_dict(model_s.state_dict())
-    for name, _ in averaged_model.named_parameters():
+
+	for name, param in averaged_model.named_parameters():
         if name in ema.shadow:
-            averaged_model.named_parameters()[name] = ema.shadow[name].clone()
+            param.data = ema.shadow[name].clone().data
     return averaged_model
 
 


### PR DESCRIPTION
Because of the past fix of average parameters cloning it was appeared an error 'TypeError: 'generator' object does not support item assignment'. Now the network works right